### PR TITLE
Add head-to-head benchmark and marketing strategy

### DIFF
--- a/MARKETING-STRATEGY.md
+++ b/MARKETING-STRATEGY.md
@@ -170,24 +170,108 @@ Level 1 and Level 2. The README already does Level 3-5 well.
 
 ---
 
-## Priority Order
+## Strategy Zero: The Benchmark (Before Everything Else)
 
-1. **The Receipts** -- Start this week. Low effort, high frequency. Use
-   existing scenario corpus. One post per day across Twitter/X, LinkedIn,
-   dev communities.
+Nothing in this document matters until you have numbers. Real numbers.
+Not internal test scenarios. Not synthetic passes. A head-to-head
+comparison that anyone can reproduce.
 
-2. **The Postmortem That Didn't Happen** -- Write 3 of these. Publish on
-   your blog and cross-post to dev.to / Hacker News. These have long
-   shelf life.
+### The Benchmark
+
+Same LLM. Same coding tasks. Two paths:
+- **Path A (Raw):** Agent produces edits, apply them directly, check if the goal was achieved
+- **Path B (Governed):** Agent runs through verify's govern() loop, check if the goal was achieved
+
+The judge is **independent of verify** — it checks ground truth by reading
+files, running syntax checks, and validating content predicates. No verify
+gate code in the evaluation. This prevents circular reasoning.
+
+### What It Measures
+
+```
+                          Raw Agent    With Verify
+Goals achieved:             12            18
+Goals failed:                6             2
+Success rate:             60.0%         90.0%
+Avg attempts:              1.0            2.1
+```
+
+And the head-to-head breakdown:
+- **verify_saved**: Raw failed, governed succeeded (verify made the difference)
+- **both_succeeded**: Both worked (verify didn't hurt)
+- **both_failed**: Neither worked (verify didn't help here)
+- **verify_regression**: Raw worked, governed failed (verify made it worse)
+
+### How To Run It
+
+```bash
+# With Gemini (cheapest)
+GEMINI_API_KEY=... npx tsx scripts/benchmark/benchmark.ts \
+  --app=fixtures/demo-app --tasks=20 --llm=gemini --verbose
+
+# With Claude
+ANTHROPIC_API_KEY=... npx tsx scripts/benchmark/benchmark.ts \
+  --app=fixtures/demo-app --tasks=20 --llm=claude --verbose
+
+# With your own app
+npx tsx scripts/benchmark/benchmark.ts \
+  --app=/path/to/your/app --tasks=30 --llm=gemini --verbose
+
+# Reuse same tasks for fair comparison across models
+npx tsx scripts/benchmark/benchmark.ts \
+  --tasks-file=.verify/benchmark/tasks-xxx.json --llm=claude
+```
+
+### Why This Comes First
+
+1. **For yourself**: You said it — without proof, this is a research project.
+   Run the benchmark. If the numbers are good, you know. If they're not,
+   you know what to fix before going public.
+
+2. **For credibility**: "Verify improved agent success rate by 34% across
+   20 coding tasks" is worth more than any demo, receipt, or postmortem.
+   It's reproducible. Anyone can run it.
+
+3. **For content**: The benchmark results BECOME the content. The numbers
+   are the receipts. The per-task breakdown is the demo. The regressions
+   (if any) are the honesty that builds trust.
+
+4. **For iteration**: Run it weekly. Track the numbers over time. When you
+   improve verify, the benchmark proves the improvement is real.
+
+### The Honest Outcomes
+
+If the numbers are good: lead with them everywhere. "34% improvement."
+That's the tweet, the README badge, the conference talk title.
+
+If the numbers are mixed: that's still honest. "Verify helped on 8/20 tasks,
+was neutral on 10, regressed on 2. Here's what we're fixing." Developers
+respect transparency more than perfection.
+
+If the numbers are bad: you saved yourself from shipping marketing for a
+product that doesn't work yet. Fix verify first. Run the benchmark again.
+
+---
+
+## Priority Order (Updated)
+
+0. **The Benchmark** -- Run it NOW. Before any content, any posts, any
+   marketing. Get the numbers. Everything else depends on what they say.
+
+1. **The Receipts** -- Start after the benchmark. Use REAL benchmark
+   results, not internal scenarios. "Task 7: agent said done, file didn't
+   exist. Verify caught it, agent retried, goal achieved."
+
+2. **The Postmortem That Didn't Happen** -- Write 3, using real benchmark
+   failures as source material.
 
 3. **CI/CD GitHub Action + Badge** -- Build the distribution channel.
-   Every repo using verify becomes a billboard.
+   The badge shows the benchmark improvement number.
 
-4. **The Live Gauntlet** -- Schedule one. Stream it. Record it. The
-   recording becomes permanent content.
+4. **The Live Gauntlet** -- Schedule one. The benchmark gives you
+   confidence to do this live because you've already seen the numbers.
 
-5. **The Silent Scoreboard** -- Build after you have enough usage data
-   to make the numbers meaningful.
+5. **The Silent Scoreboard** -- Build after you have enough usage data.
 
 ---
 

--- a/scripts/benchmark/benchmark.ts
+++ b/scripts/benchmark/benchmark.ts
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+/**
+ * Benchmark CLI — Prove Verify Works (or Doesn't)
+ * =================================================
+ *
+ * npx tsx scripts/benchmark/benchmark.ts [options]
+ *
+ * Options:
+ *   --app=<path>              App directory to benchmark against (default: fixtures/demo-app)
+ *   --tasks=<n>               Number of tasks to generate (default: 20)
+ *   --max-attempts=<n>        Max govern() attempts (default: 3)
+ *   --llm=gemini|claude|anthropic|ollama  LLM provider (default: gemini)
+ *   --api-key=<key>           API key (or set GEMINI_API_KEY / ANTHROPIC_API_KEY)
+ *   --model=<model>           Model override
+ *   --state-dir=<path>        State directory (default: .verify/benchmark)
+ *   --verbose                 Show detailed per-task output
+ *   --tasks-file=<path>       Load tasks from JSON file instead of generating
+ *
+ * The benchmark:
+ *   1. Generates N coding tasks for the app (using the LLM)
+ *   2. For each task, runs the agent twice:
+ *      a. RAW: Agent produces edits, applied directly, checked by ground truth
+ *      b. GOVERNED: Agent runs through govern(), checked by ground truth
+ *   3. Ground truth is independent of verify — no verify code in the judge
+ *   4. Produces a comparison table: success rates, tasks saved, regressions
+ *
+ * This is the proof. Run it. Look at the numbers.
+ */
+
+import { resolve, join } from 'path';
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { runBenchmark } from './runner.js';
+import { groundInReality } from '../../src/gates/grounding.js';
+import type { BenchmarkConfig, BenchmarkTask, LLMCallFn } from './types.js';
+
+// =============================================================================
+// ARG PARSING
+// =============================================================================
+
+function parseArgs(): Record<string, string> {
+  const args: Record<string, string> = {};
+  for (const arg of process.argv.slice(2)) {
+    if (arg.startsWith('--')) {
+      const [key, ...rest] = arg.slice(2).split('=');
+      args[key] = rest.join('=') || 'true';
+    }
+  }
+  return args;
+}
+
+// =============================================================================
+// LLM PROVIDERS
+// =============================================================================
+
+function createLLM(provider: string, apiKey: string, model?: string): { llm: LLMCallFn; model: string } {
+  switch (provider) {
+    case 'gemini': {
+      const m = model ?? 'gemini-2.5-flash';
+      return {
+        model: m,
+        llm: async (system, user) => {
+          const url = `https://generativelanguage.googleapis.com/v1beta/models/${m}:generateContent?key=${apiKey}`;
+          const resp = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              system_instruction: { parts: [{ text: system }] },
+              contents: [{ role: 'user', parts: [{ text: user }] }],
+              generationConfig: { temperature: 0.3, maxOutputTokens: 4096 },
+            }),
+          });
+          if (!resp.ok) throw new Error(`Gemini ${resp.status}: ${(await resp.text()).slice(0, 200)}`);
+          const data = await resp.json() as any;
+          const text = data.candidates?.[0]?.content?.parts
+            ?.filter((p: any) => p.text && !p.thought)
+            ?.map((p: any) => p.text).join('') || '';
+          const usage = data.usageMetadata ?? {};
+          return { text, inputTokens: usage.promptTokenCount ?? 0, outputTokens: usage.candidatesTokenCount ?? 0 };
+        },
+      };
+    }
+    case 'claude':
+    case 'anthropic': {
+      const m = model ?? 'claude-sonnet-4-20250514';
+      return {
+        model: m,
+        llm: async (system, user) => {
+          const resp = await fetch('https://api.anthropic.com/v1/messages', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': apiKey,
+              'anthropic-version': '2023-06-01',
+            },
+            body: JSON.stringify({
+              model: m,
+              max_tokens: 4096,
+              temperature: 0.3,
+              system,
+              messages: [{ role: 'user', content: user }],
+            }),
+          });
+          if (!resp.ok) throw new Error(`Anthropic ${resp.status}: ${(await resp.text()).slice(0, 200)}`);
+          const data = await resp.json() as any;
+          const text = data.content?.map((b: any) => b.text).join('') ?? '';
+          return {
+            text,
+            inputTokens: data.usage?.input_tokens ?? 0,
+            outputTokens: data.usage?.output_tokens ?? 0,
+          };
+        },
+      };
+    }
+    case 'ollama': {
+      const m = model ?? 'qwen3:4b';
+      const host = process.env.OLLAMA_HOST ?? 'http://localhost:11434';
+      return {
+        model: m,
+        llm: async (system, user) => {
+          const resp = await fetch(`${host}/api/generate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              model: m,
+              system,
+              prompt: user,
+              stream: false,
+              options: { temperature: 0.3 },
+            }),
+          });
+          if (!resp.ok) throw new Error(`Ollama ${resp.status}`);
+          const data = await resp.json() as any;
+          return { text: data.response ?? '', inputTokens: data.prompt_eval_count ?? 0, outputTokens: data.eval_count ?? 0 };
+        },
+      };
+    }
+    default:
+      throw new Error(`Unknown LLM provider: ${provider}. Use gemini, claude, anthropic, or ollama.`);
+  }
+}
+
+// =============================================================================
+// TASK GENERATION
+// =============================================================================
+
+const TASK_GEN_SYSTEM = `You are generating benchmark tasks for a code verification system.
+Each task is a realistic coding goal that an AI agent would be asked to do.
+
+Generate tasks that:
+1. Are achievable with search/replace edits on the given source files
+2. Span different difficulty levels (trivial, moderate, hard)
+3. Cover different categories (CSS changes, HTML changes, logic changes, config changes)
+4. Have clear success criteria
+5. Are independent of each other
+
+Respond with a JSON array of tasks. No markdown fencing.
+Each task: { "goal": "...", "category": "...", "difficulty": "trivial|moderate|hard" }`;
+
+async function generateTasks(
+  appDir: string,
+  count: number,
+  llm: LLMCallFn,
+): Promise<BenchmarkTask[]> {
+  console.log(`Generating ${count} benchmark tasks...`);
+
+  // Build context from app
+  const grounding = groundInReality(appDir);
+  const lines: string[] = [];
+  lines.push(`App directory: ${appDir}`);
+  lines.push(`Routes: ${grounding.routes.join(', ')}`);
+  lines.push('');
+
+  // Read source files for context
+  const { readdirSync, statSync } = require('fs');
+  const sourceExts = new Set(['.js', '.ts', '.html', '.css', '.json']);
+  const skipDirs = new Set(['node_modules', '.git', '.verify']);
+
+  function walk(dir: string, prefix: string = ''): void {
+    try {
+      for (const entry of readdirSync(dir)) {
+        if (skipDirs.has(entry)) continue;
+        const full = join(dir, entry);
+        const rel = prefix ? `${prefix}/${entry}` : entry;
+        const stat = statSync(full);
+        if (stat.isDirectory()) walk(full, rel);
+        else if (sourceExts.has(require('path').extname(entry)) && stat.size < 15_000) {
+          lines.push(`--- ${rel} ---`);
+          lines.push(readFileSync(full, 'utf-8'));
+          lines.push('');
+        }
+      }
+    } catch { /* skip */ }
+  }
+  walk(appDir);
+
+  const prompt = `Generate exactly ${count} benchmark tasks for this app.\n\n${lines.join('\n')}`;
+  const response = await llm(TASK_GEN_SYSTEM, prompt);
+
+  let parsed: any[];
+  try {
+    let text = response.text.trim();
+    if (text.startsWith('```')) text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+    parsed = JSON.parse(text);
+  } catch {
+    const match = response.text.match(/\[[\s\S]*\]/);
+    if (match) parsed = JSON.parse(match[0]);
+    else throw new Error('Failed to parse task generation response');
+  }
+
+  return parsed.map((t: any, i: number) => ({
+    id: `task_${i + 1}`,
+    goal: t.goal,
+    appDir,
+    predicates: t.predicates ?? [],
+    category: t.category ?? 'general',
+    difficulty: t.difficulty ?? 'moderate',
+  }));
+}
+
+// =============================================================================
+// MAIN
+// =============================================================================
+
+async function main() {
+  const args = parseArgs();
+
+  const appDir = resolve(args['app'] ?? join(__dirname, '../../fixtures/demo-app'));
+  const taskCount = parseInt(args['tasks'] ?? '20', 10);
+  const maxAttempts = parseInt(args['max-attempts'] ?? '3', 10);
+  const provider = args['llm'] ?? 'gemini';
+  const stateDir = resolve(args['state-dir'] ?? '.verify/benchmark');
+  const verbose = args['verbose'] === 'true';
+  const tasksFile = args['tasks-file'];
+
+  // Resolve API key
+  let apiKey = args['api-key'] ?? '';
+  if (!apiKey) {
+    if (provider === 'gemini') apiKey = process.env.GEMINI_API_KEY ?? '';
+    if (provider === 'claude' || provider === 'anthropic') apiKey = process.env.ANTHROPIC_API_KEY ?? '';
+  }
+  if (!apiKey && provider !== 'ollama') {
+    console.error(`Error: No API key. Set --api-key or the appropriate env var.`);
+    process.exit(1);
+  }
+
+  if (!existsSync(appDir)) {
+    console.error(`Error: App directory not found: ${appDir}`);
+    process.exit(1);
+  }
+
+  // Create LLM
+  const { llm, model } = createLLM(provider, apiKey, args['model']);
+
+  // Get or generate tasks
+  let tasks: BenchmarkTask[];
+  if (tasksFile && existsSync(tasksFile)) {
+    console.log(`Loading tasks from ${tasksFile}...`);
+    tasks = JSON.parse(readFileSync(tasksFile, 'utf-8'));
+    // Set appDir on loaded tasks
+    tasks = tasks.map(t => ({ ...t, appDir }));
+  } else {
+    tasks = await generateTasks(appDir, taskCount, llm);
+    // Save generated tasks for reproducibility
+    mkdirSync(stateDir, { recursive: true });
+    const tasksPath = join(stateDir, `tasks-${Date.now()}.json`);
+    writeFileSync(tasksPath, JSON.stringify(tasks, null, 2));
+    console.log(`Tasks saved to: ${tasksPath} (use --tasks-file to reuse)`);
+  }
+
+  console.log(`\nLoaded ${tasks.length} tasks for ${appDir}`);
+
+  // Run benchmark
+  const config: BenchmarkConfig = {
+    tasks,
+    llm,
+    llmProvider: provider,
+    model,
+    maxGovAttempts: maxAttempts,
+    stateDir,
+    verbose,
+    skipDocker: true,
+  };
+
+  const run = await runBenchmark(config);
+
+  // Exit code: 0 if verify helped or was neutral, 1 if regression
+  if (run.summary.headToHead.verifyRegression > run.summary.headToHead.verifySaved) {
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error(`\nBenchmark failed: ${err.message}`);
+  console.error(err.stack);
+  process.exit(1);
+});

--- a/scripts/benchmark/ground-truth.ts
+++ b/scripts/benchmark/ground-truth.ts
@@ -1,0 +1,224 @@
+/**
+ * Ground Truth Validator — Independent of Verify
+ * ================================================
+ *
+ * This is the judge. It does NOT use any verify gate code.
+ * It checks: did the file changes actually apply? Do content predicates hold?
+ * Does the app still work?
+ *
+ * If this uses verify internals, the benchmark is circular. Keep it clean.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import type { Edit, Predicate } from '../../src/types.js';
+import type { GroundTruthResult } from './types.js';
+
+// =============================================================================
+// FILE CHECKS — did the edits actually land?
+// =============================================================================
+
+function checkFilesApplied(
+  appDir: string,
+  edits: Edit[],
+): { applied: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  for (const edit of edits) {
+    const filePath = join(appDir, edit.file);
+
+    if (!existsSync(filePath)) {
+      errors.push(`File not found: ${edit.file}`);
+      continue;
+    }
+
+    const content = readFileSync(filePath, 'utf-8');
+
+    // The replace string should be present in the file
+    if (!content.includes(edit.replace)) {
+      errors.push(`Expected content not found in ${edit.file}: "${edit.replace.slice(0, 60)}..."`);
+    }
+
+    // The search string should NOT be present (it was replaced)
+    // Unless search === replace (no-op) or replace contains search
+    if (edit.search !== edit.replace && !edit.replace.includes(edit.search)) {
+      if (content.includes(edit.search)) {
+        errors.push(`Original content still present in ${edit.file}: "${edit.search.slice(0, 60)}..."`);
+      }
+    }
+  }
+
+  return { applied: errors.length === 0, errors };
+}
+
+// =============================================================================
+// CONTENT PREDICATE CHECKS — independent of verify's gate logic
+// =============================================================================
+
+function checkContentPredicates(
+  appDir: string,
+  predicates: Predicate[],
+): Array<{ predicate: Predicate; passed: boolean; reason: string }> {
+  const results: Array<{ predicate: Predicate; passed: boolean; reason: string }> = [];
+
+  for (const pred of predicates) {
+    if (pred.type === 'content' && pred.file && pred.pattern) {
+      const filePath = join(appDir, pred.file);
+      if (!existsSync(filePath)) {
+        results.push({ predicate: pred, passed: false, reason: `File not found: ${pred.file}` });
+        continue;
+      }
+      const content = readFileSync(filePath, 'utf-8');
+      const found = content.includes(pred.pattern);
+      results.push({
+        predicate: pred,
+        passed: found,
+        reason: found ? 'Pattern found' : `Pattern not found: "${pred.pattern.slice(0, 60)}"`,
+      });
+    }
+
+    if (pred.type === 'filesystem_exists' && pred.file) {
+      const filePath = join(appDir, pred.file);
+      const exists = existsSync(filePath);
+      results.push({
+        predicate: pred,
+        passed: exists,
+        reason: exists ? 'File exists' : `File not found: ${pred.file}`,
+      });
+    }
+
+    if (pred.type === 'filesystem_absent' && pred.file) {
+      const filePath = join(appDir, pred.file);
+      const absent = !existsSync(filePath);
+      results.push({
+        predicate: pred,
+        passed: absent,
+        reason: absent ? 'File absent as expected' : `File unexpectedly exists: ${pred.file}`,
+      });
+    }
+
+    // CSS and HTML predicates need a browser — skip if no Docker
+    if (pred.type === 'css' || pred.type === 'html') {
+      results.push({
+        predicate: pred,
+        passed: false,
+        reason: 'Requires browser (skipped in ground-truth, file checks only)',
+      });
+    }
+  }
+
+  return results;
+}
+
+// =============================================================================
+// APP HEALTH — does the app still start?
+// =============================================================================
+
+function checkAppStarts(appDir: string): { starts: boolean; error: string } {
+  // Try node --check on server files (syntax validation)
+  const serverFiles = ['server.js', 'index.js', 'app.js', 'server.ts', 'index.ts', 'app.ts'];
+
+  for (const file of serverFiles) {
+    const filePath = join(appDir, file);
+    if (existsSync(filePath)) {
+      // For .ts files, just check they're parseable
+      if (file.endsWith('.ts')) {
+        try {
+          readFileSync(filePath, 'utf-8');
+          return { starts: true, error: '' };
+        } catch (err: any) {
+          return { starts: false, error: `Cannot read ${file}: ${err.message}` };
+        }
+      }
+      // For .js files, use node --check
+      try {
+        execSync(`node --check "${filePath}"`, {
+          cwd: appDir,
+          timeout: 10_000,
+          stdio: 'pipe',
+        });
+        return { starts: true, error: '' };
+      } catch (err: any) {
+        return { starts: false, error: `node --check ${file} failed: ${err.stderr?.toString().slice(0, 200) ?? err.message}` };
+      }
+    }
+  }
+
+  // No server file found — can't check
+  return { starts: true, error: '' };
+}
+
+// =============================================================================
+// TEST RUNNER — does npm test / pytest pass?
+// =============================================================================
+
+function checkTestsPass(appDir: string): { pass: boolean | null; output: string } {
+  const packageJson = join(appDir, 'package.json');
+  if (existsSync(packageJson)) {
+    try {
+      const pkg = JSON.parse(readFileSync(packageJson, 'utf-8'));
+      if (pkg.scripts?.test && pkg.scripts.test !== 'echo "Error: no test specified" && exit 1') {
+        const result = execSync('npm test', {
+          cwd: appDir,
+          timeout: 30_000,
+          stdio: 'pipe',
+        });
+        return { pass: true, output: result.toString().slice(-500) };
+      }
+    } catch (err: any) {
+      const output = err.stdout?.toString().slice(-300) ?? '';
+      const stderr = err.stderr?.toString().slice(-300) ?? '';
+      return { pass: false, output: `${output}\n${stderr}`.trim() };
+    }
+  }
+
+  // No test runner found
+  return { pass: null, output: 'No test command found' };
+}
+
+// =============================================================================
+// PUBLIC API
+// =============================================================================
+
+/**
+ * Run independent ground-truth validation.
+ * Does NOT use any verify code. That's the whole point.
+ */
+export function validateGroundTruth(
+  appDir: string,
+  edits: Edit[],
+  predicates: Predicate[],
+): GroundTruthResult {
+  // 1. Did the file changes apply?
+  const fileCheck = checkFilesApplied(appDir, edits);
+
+  // 2. Do content predicates hold?
+  const predResults = checkContentPredicates(appDir, predicates);
+  const checkablePredicates = predResults.filter(r =>
+    r.predicate.type !== 'css' && r.predicate.type !== 'html'
+  );
+  const contentPass = checkablePredicates.length === 0 ||
+    checkablePredicates.every(r => r.passed);
+
+  // 3. Does the app still start?
+  const appCheck = checkAppStarts(appDir);
+
+  // 4. Do tests pass?
+  const testCheck = checkTestsPass(appDir);
+
+  // Overall: files applied + content predicates hold + app doesn't crash
+  const goalAchieved = fileCheck.applied && contentPass && appCheck.starts;
+
+  return {
+    filesApplied: fileCheck.applied,
+    fileErrors: fileCheck.errors,
+    testsPass: testCheck.pass,
+    testOutput: testCheck.output,
+    appStarts: appCheck.starts,
+    startupError: appCheck.error,
+    contentPredicatesPass: contentPass,
+    predicateResults: predResults,
+    goalAchieved,
+  };
+}

--- a/scripts/benchmark/runner.ts
+++ b/scripts/benchmark/runner.ts
@@ -1,0 +1,601 @@
+/**
+ * Benchmark Runner — The Head-to-Head Test
+ * ==========================================
+ *
+ * Same agent. Same tasks. Two paths.
+ *   Path A: Agent edits, apply raw, check ground truth.
+ *   Path B: Agent edits through govern(), check ground truth.
+ *
+ * Ground truth is checked independently — not by verify.
+ * This is the proof. If the numbers are good, verify works.
+ * If they're not, verify is a research project.
+ */
+
+import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { verify } from '../../src/verify.js';
+import { govern } from '../../src/govern.js';
+import type { GovernAgent, GovernContext, AgentPlan } from '../../src/govern.js';
+import { applyEdits } from '../../src/gates/syntax.js';
+import { groundInReality } from '../../src/gates/grounding.js';
+import { validateGroundTruth } from './ground-truth.js';
+import type {
+  BenchmarkConfig, BenchmarkTask, BenchmarkRun, BenchmarkSummary,
+  TaskComparison, RawRunResult, GovernedRunResult, LLMCallFn,
+} from './types.js';
+
+// =============================================================================
+// EDIT GENERATION PROMPT (shared between raw and governed paths)
+// =============================================================================
+
+const AGENT_SYSTEM = `You are a coding agent. Given a goal and the app's source code, produce search/replace edits.
+
+Rules:
+1. "search" must be an EXACT substring in the file — copy verbatim
+2. "search" must appear EXACTLY ONCE in the file
+3. "replace" is what replaces it
+4. Keep edits minimal
+5. Include predicates that verify the goal was achieved
+
+Respond with JSON only (no markdown):
+{
+  "edits": [{ "file": "path", "search": "exact", "replace": "new" }],
+  "predicates": [{ "type": "content", "file": "path", "pattern": "expected text" }]
+}`;
+
+function buildAgentPrompt(
+  task: BenchmarkTask,
+  appDir: string,
+  priorFailure?: string,
+): string {
+  const lines: string[] = [];
+
+  lines.push(`Goal: ${task.goal}`);
+  lines.push('');
+
+  if (priorFailure) {
+    lines.push('PREVIOUS ATTEMPT FAILED:');
+    lines.push(priorFailure);
+    lines.push('Fix the issue and try again.');
+    lines.push('');
+  }
+
+  // Read source files
+  const sourceExts = new Set(['.js', '.ts', '.jsx', '.tsx', '.html', '.css', '.json', '.sql']);
+  const skipDirs = new Set(['node_modules', '.git', '.next', 'dist', '.verify', 'coverage']);
+
+  function readDir(dir: string, prefix: string = ''): void {
+    try {
+      const { readdirSync, statSync } = require('fs');
+      const entries = readdirSync(dir);
+      for (const entry of entries) {
+        if (skipDirs.has(entry)) continue;
+        const full = join(dir, entry);
+        const rel = prefix ? `${prefix}/${entry}` : entry;
+        const stat = statSync(full);
+        if (stat.isDirectory()) {
+          readDir(full, rel);
+        } else if (sourceExts.has(require('path').extname(entry))) {
+          if (stat.size > 20_000) continue; // skip huge files
+          const content = readFileSync(full, 'utf-8');
+          lines.push(`--- ${rel} ---`);
+          lines.push(content);
+          lines.push('');
+        }
+      }
+    } catch { /* skip unreadable dirs */ }
+  }
+
+  lines.push('Source files:');
+  readDir(appDir);
+
+  return lines.join('\n');
+}
+
+// =============================================================================
+// PARSE LLM RESPONSE
+// =============================================================================
+
+function parseLLMResponse(text: string): { edits: any[]; predicates: any[] } {
+  // Strip markdown fences if present
+  let cleaned = text.trim();
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+  }
+
+  try {
+    const parsed = JSON.parse(cleaned);
+    return {
+      edits: Array.isArray(parsed.edits) ? parsed.edits : [],
+      predicates: Array.isArray(parsed.predicates) ? parsed.predicates : [],
+    };
+  } catch {
+    // Try to extract JSON from the response
+    const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      try {
+        const parsed = JSON.parse(jsonMatch[0]);
+        return {
+          edits: Array.isArray(parsed.edits) ? parsed.edits : [],
+          predicates: Array.isArray(parsed.predicates) ? parsed.predicates : [],
+        };
+      } catch { /* fall through */ }
+    }
+    return { edits: [], predicates: [] };
+  }
+}
+
+// =============================================================================
+// ISOLATED APP COPY — each run gets its own copy
+// =============================================================================
+
+function makeIsolatedCopy(appDir: string, label: string): string {
+  const copyDir = join(tmpdir(), `verify-bench-${label}-${Date.now()}`);
+  mkdirSync(copyDir, { recursive: true });
+  cpSync(appDir, copyDir, { recursive: true });
+  return copyDir;
+}
+
+function cleanup(dir: string): void {
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+}
+
+// =============================================================================
+// PATH A: RAW AGENT (no verify)
+// =============================================================================
+
+async function runRaw(
+  task: BenchmarkTask,
+  llm: LLMCallFn,
+  verbose: boolean,
+): Promise<RawRunResult> {
+  const start = Date.now();
+  let totalInput = 0;
+  let totalOutput = 0;
+
+  if (verbose) log(`  [RAW] Starting raw agent run...`);
+
+  // Get agent's edits
+  let edits: any[] = [];
+  let predicates: any[] = [];
+  let agentError: string | null = null;
+
+  try {
+    const prompt = buildAgentPrompt(task, task.appDir);
+    const response = await llm(AGENT_SYSTEM, prompt);
+    totalInput += response.inputTokens;
+    totalOutput += response.outputTokens;
+    const parsed = parseLLMResponse(response.text);
+    edits = parsed.edits;
+    predicates = parsed.predicates;
+  } catch (err: any) {
+    agentError = err.message;
+  }
+
+  if (edits.length === 0 && !agentError) {
+    if (verbose) log(`  [RAW] Agent produced no edits`);
+    return {
+      edits: [],
+      predicates: [],
+      agentProducedEdits: false,
+      agentError,
+      groundTruth: emptyGroundTruth(),
+      durationMs: Date.now() - start,
+      tokens: { input: totalInput, output: totalOutput },
+    };
+  }
+
+  // Apply edits to isolated copy
+  const copyDir = makeIsolatedCopy(task.appDir, `raw-${task.id}`);
+  try {
+    // Apply edits manually (no verify involvement)
+    for (const edit of edits) {
+      const filePath = join(copyDir, edit.file);
+      if (!existsSync(filePath)) continue;
+      let content = readFileSync(filePath, 'utf-8');
+      if (content.includes(edit.search)) {
+        content = content.replace(edit.search, edit.replace);
+        writeFileSync(filePath, content);
+      }
+    }
+
+    // Check ground truth
+    const groundTruth = validateGroundTruth(copyDir, edits, predicates);
+
+    if (verbose) {
+      log(`  [RAW] Ground truth: ${groundTruth.goalAchieved ? 'ACHIEVED' : 'FAILED'}`);
+      if (!groundTruth.goalAchieved) {
+        for (const err of groundTruth.fileErrors.slice(0, 3)) log(`    - ${err}`);
+      }
+    }
+
+    return {
+      edits,
+      predicates,
+      agentProducedEdits: true,
+      agentError,
+      groundTruth,
+      durationMs: Date.now() - start,
+      tokens: { input: totalInput, output: totalOutput },
+    };
+  } finally {
+    cleanup(copyDir);
+  }
+}
+
+// =============================================================================
+// PATH B: GOVERNED AGENT (with verify)
+// =============================================================================
+
+async function runGoverned(
+  task: BenchmarkTask,
+  llm: LLMCallFn,
+  maxAttempts: number,
+  stateDir: string,
+  verbose: boolean,
+): Promise<GovernedRunResult> {
+  const start = Date.now();
+  let totalInput = 0;
+  let totalOutput = 0;
+  let lastEdits: any[] = [];
+  let lastPredicates: any[] = [];
+
+  if (verbose) log(`  [GOV] Starting governed run (max ${maxAttempts} attempts)...`);
+
+  // Make an isolated copy for the governed run
+  const copyDir = makeIsolatedCopy(task.appDir, `gov-${task.id}`);
+  const govStateDir = join(copyDir, '.verify');
+  mkdirSync(govStateDir, { recursive: true });
+
+  try {
+    // Build a GovernAgent that calls the LLM
+    const agent: GovernAgent = {
+      plan: async (goal: string, ctx: GovernContext): Promise<AgentPlan> => {
+        let priorFailure: string | undefined;
+        if (ctx.priorResult && !ctx.priorResult.success) {
+          const failedGate = ctx.priorResult.gates.find(g => !g.passed);
+          priorFailure = failedGate
+            ? `Gate "${failedGate.gate}" failed: ${failedGate.details?.reason ?? 'unknown'}`
+            : 'Unknown failure';
+          if (ctx.narrowing?.hint) {
+            priorFailure += `\nHint: ${ctx.narrowing.hint}`;
+          }
+          if (ctx.constraints.length > 0) {
+            priorFailure += '\nConstraints: ' + ctx.constraints.map(c => c.reason).join('; ');
+          }
+        }
+
+        const prompt = buildAgentPrompt(task, copyDir, priorFailure);
+        const response = await llm(AGENT_SYSTEM, prompt);
+        totalInput += response.inputTokens;
+        totalOutput += response.outputTokens;
+
+        const parsed = parseLLMResponse(response.text);
+        lastEdits = parsed.edits;
+        lastPredicates = parsed.predicates;
+        return { edits: parsed.edits, predicates: parsed.predicates };
+      },
+    };
+
+    const result = await govern({
+      appDir: copyDir,
+      goal: task.goal,
+      agent,
+      maxAttempts,
+      stateDir: govStateDir,
+      gates: {
+        staging: false,   // no Docker in benchmark by default
+        browser: false,
+        http: false,
+        vision: false,
+      },
+      onAttempt: (attempt, verifyResult) => {
+        if (verbose) {
+          const verdict = verifyResult.success ? 'PASS' : 'FAIL';
+          const gate = verifyResult.gates.find(g => !g.passed)?.gate ?? '-';
+          log(`  [GOV] Attempt ${attempt}: ${verdict} (gate: ${gate})`);
+        }
+      },
+    });
+
+    // Check ground truth on the final state of the copy
+    const groundTruth = validateGroundTruth(copyDir, lastEdits, lastPredicates);
+
+    if (verbose) {
+      log(`  [GOV] Stop reason: ${result.convergence.stopReason}`);
+      log(`  [GOV] Ground truth: ${groundTruth.goalAchieved ? 'ACHIEVED' : 'FAILED'}`);
+    }
+
+    return {
+      edits: lastEdits,
+      predicates: lastPredicates,
+      attempts: result.attempts.length,
+      stopReason: result.convergence.stopReason ?? 'exhausted',
+      verifyPassed: result.success,
+      agentError: null,
+      groundTruth,
+      durationMs: Date.now() - start,
+      tokens: { input: totalInput, output: totalOutput },
+    };
+  } catch (err: any) {
+    return {
+      edits: lastEdits,
+      predicates: lastPredicates,
+      attempts: 0,
+      stopReason: 'agent_error',
+      verifyPassed: false,
+      agentError: err.message,
+      groundTruth: emptyGroundTruth(),
+      durationMs: Date.now() - start,
+      tokens: { input: totalInput, output: totalOutput },
+    };
+  } finally {
+    cleanup(copyDir);
+  }
+}
+
+// =============================================================================
+// COMPARE — classify the outcome
+// =============================================================================
+
+function compareResults(
+  task: BenchmarkTask,
+  raw: RawRunResult,
+  governed: GovernedRunResult,
+): TaskComparison {
+  const rawAchieved = raw.groundTruth.goalAchieved;
+  const govAchieved = governed.groundTruth.goalAchieved;
+
+  let outcome: TaskComparison['verdict']['outcome'];
+
+  if (!raw.agentProducedEdits && governed.edits.length === 0) {
+    outcome = 'both_no_edits';
+  } else if (!raw.agentProducedEdits) {
+    outcome = 'raw_no_edits';
+  } else if (governed.edits.length === 0) {
+    outcome = 'governed_no_edits';
+  } else if (!rawAchieved && govAchieved) {
+    outcome = 'verify_saved';
+  } else if (rawAchieved && govAchieved) {
+    outcome = 'both_succeeded';
+  } else if (!rawAchieved && !govAchieved) {
+    outcome = 'both_failed';
+  } else if (rawAchieved && !govAchieved) {
+    outcome = 'verify_regression';
+  } else {
+    outcome = 'verify_overhead';
+  }
+
+  return {
+    task,
+    raw,
+    governed,
+    verdict: { rawAchieved, governedAchieved: govAchieved, outcome },
+  };
+}
+
+// =============================================================================
+// SUMMARY — compute the headline numbers
+// =============================================================================
+
+function computeSummary(comparisons: TaskComparison[]): BenchmarkSummary {
+  const total = comparisons.length;
+
+  const rawAchieved = comparisons.filter(c => c.verdict.rawAchieved).length;
+  const govAchieved = comparisons.filter(c => c.verdict.governedAchieved).length;
+
+  const rawNoEdits = comparisons.filter(c => !c.raw.agentProducedEdits).length;
+  const govNoEdits = comparisons.filter(c => c.governed.edits.length === 0).length;
+
+  const rawTokens = comparisons.reduce((acc, c) => ({
+    input: acc.input + c.raw.tokens.input,
+    output: acc.output + c.raw.tokens.output,
+  }), { input: 0, output: 0 });
+
+  const govTokens = comparisons.reduce((acc, c) => ({
+    input: acc.input + c.governed.tokens.input,
+    output: acc.output + c.governed.tokens.output,
+  }), { input: 0, output: 0 });
+
+  const verifySaved = comparisons.filter(c => c.verdict.outcome === 'verify_saved').length;
+  const bothSucceeded = comparisons.filter(c => c.verdict.outcome === 'both_succeeded').length;
+  const bothFailed = comparisons.filter(c => c.verdict.outcome === 'both_failed').length;
+  const verifyOverhead = comparisons.filter(c => c.verdict.outcome === 'verify_overhead').length;
+  const verifyRegression = comparisons.filter(c => c.verdict.outcome === 'verify_regression').length;
+
+  const rawSuccessRate = total > 0 ? rawAchieved / total : 0;
+  const govSuccessRate = total > 0 ? govAchieved / total : 0;
+  const improvement = rawSuccessRate > 0
+    ? ((govSuccessRate - rawSuccessRate) / rawSuccessRate) * 100
+    : govSuccessRate > 0 ? 100 : 0;
+
+  return {
+    totalTasks: total,
+    raw: {
+      goalsAchieved: rawAchieved,
+      goalsFailed: total - rawAchieved - rawNoEdits,
+      noEdits: rawNoEdits,
+      successRate: rawSuccessRate,
+      avgDurationMs: total > 0
+        ? comparisons.reduce((s, c) => s + c.raw.durationMs, 0) / total : 0,
+      totalTokens: rawTokens,
+    },
+    governed: {
+      goalsAchieved: govAchieved,
+      goalsFailed: total - govAchieved - govNoEdits,
+      noEdits: govNoEdits,
+      successRate: govSuccessRate,
+      avgAttempts: total > 0
+        ? comparisons.reduce((s, c) => s + c.governed.attempts, 0) / total : 0,
+      avgDurationMs: total > 0
+        ? comparisons.reduce((s, c) => s + c.governed.durationMs, 0) / total : 0,
+      totalTokens: govTokens,
+    },
+    headToHead: {
+      verifySaved,
+      bothSucceeded,
+      bothFailed,
+      verifyOverhead,
+      verifyRegression,
+    },
+    improvementPercent: improvement,
+    netTasksSaved: verifySaved - verifyRegression,
+  };
+}
+
+// =============================================================================
+// REPORT — human-readable output
+// =============================================================================
+
+function printReport(run: BenchmarkRun): void {
+  const s = run.summary;
+  const divider = '═'.repeat(60);
+
+  log(`\n${divider}`);
+  log(`  VERIFY BENCHMARK — ${run.llmProvider} / ${run.model}`);
+  log(`  ${run.comparisons.length} tasks, ${run.apps.join(', ')}`);
+  log(divider);
+
+  log(`\n  HEAD-TO-HEAD RESULTS`);
+  log(`  ${'─'.repeat(50)}`);
+  log(`                          Raw Agent    With Verify`);
+  log(`  Goals achieved:         ${pad(s.raw.goalsAchieved)}           ${pad(s.governed.goalsAchieved)}`);
+  log(`  Goals failed:           ${pad(s.raw.goalsFailed)}           ${pad(s.governed.goalsFailed)}`);
+  log(`  No edits produced:      ${pad(s.raw.noEdits)}           ${pad(s.governed.noEdits)}`);
+  log(`  Success rate:           ${pct(s.raw.successRate)}        ${pct(s.governed.successRate)}`);
+  log(`  Avg duration:           ${ms(s.raw.avgDurationMs)}      ${ms(s.governed.avgDurationMs)}`);
+  log(`  Avg attempts:           1.0            ${s.governed.avgAttempts.toFixed(1)}`);
+
+  log(`\n  VERDICT BREAKDOWN`);
+  log(`  ${'─'.repeat(50)}`);
+  log(`  Verify saved the task:     ${s.headToHead.verifySaved}`);
+  log(`  Both succeeded:            ${s.headToHead.bothSucceeded}`);
+  log(`  Both failed:               ${s.headToHead.bothFailed}`);
+  log(`  Verify overhead (harmless):${s.headToHead.verifyOverhead}`);
+  log(`  Verify regression:         ${s.headToHead.verifyRegression}`);
+
+  log(`\n  THE HEADLINE`);
+  log(`  ${'─'.repeat(50)}`);
+
+  if (s.improvementPercent > 0) {
+    log(`  Verify improved success rate by ${s.improvementPercent.toFixed(1)}%`);
+    log(`  Net tasks saved: ${s.netTasksSaved}`);
+  } else if (s.improvementPercent === 0) {
+    log(`  No difference in success rate.`);
+  } else {
+    log(`  Verify DECREASED success rate by ${Math.abs(s.improvementPercent).toFixed(1)}%`);
+    log(`  Net regressions: ${Math.abs(s.netTasksSaved)}`);
+  }
+
+  log(`\n  TOKEN COST`);
+  log(`  ${'─'.repeat(50)}`);
+  log(`  Raw:      ${s.raw.totalTokens.input.toLocaleString()} in / ${s.raw.totalTokens.output.toLocaleString()} out`);
+  log(`  Governed: ${s.governed.totalTokens.input.toLocaleString()} in / ${s.governed.totalTokens.output.toLocaleString()} out`);
+  log(`  Overhead: ${((s.governed.totalTokens.input + s.governed.totalTokens.output) / Math.max(1, s.raw.totalTokens.input + s.raw.totalTokens.output)).toFixed(1)}x tokens`);
+
+  log(`\n${divider}`);
+
+  // Per-task breakdown
+  log(`\n  PER-TASK BREAKDOWN`);
+  log(`  ${'─'.repeat(50)}`);
+  for (const c of run.comparisons) {
+    const icon = c.verdict.outcome === 'verify_saved' ? '+' :
+                 c.verdict.outcome === 'both_succeeded' ? '=' :
+                 c.verdict.outcome === 'verify_regression' ? '!' :
+                 c.verdict.outcome === 'both_failed' ? 'x' : '-';
+    log(`  [${icon}] ${c.task.goal.slice(0, 55).padEnd(55)} ${c.verdict.outcome}`);
+  }
+
+  log(`\n${divider}\n`);
+}
+
+// =============================================================================
+// MAIN RUNNER
+// =============================================================================
+
+export async function runBenchmark(config: BenchmarkConfig): Promise<BenchmarkRun> {
+  const runId = `bench_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+  const startedAt = new Date().toISOString();
+
+  log(`\nVerify Benchmark — ${config.tasks.length} tasks`);
+  log(`LLM: ${config.llmProvider} / ${config.model}`);
+  log(`Max govern attempts: ${config.maxGovAttempts}`);
+  log(`${'─'.repeat(50)}`);
+
+  const comparisons: TaskComparison[] = [];
+
+  for (let i = 0; i < config.tasks.length; i++) {
+    const task = config.tasks[i];
+    log(`\n[${i + 1}/${config.tasks.length}] ${task.goal}`);
+    log(`  Category: ${task.category}, Difficulty: ${task.difficulty}`);
+
+    // Run both paths
+    const raw = await runRaw(task, config.llm, config.verbose);
+    const governed = await runGoverned(
+      task, config.llm, config.maxGovAttempts, config.stateDir, config.verbose,
+    );
+
+    // Compare
+    const comparison = compareResults(task, raw, governed);
+    comparisons.push(comparison);
+
+    // Live progress
+    const icon = comparison.verdict.outcome === 'verify_saved' ? '[+]' :
+                 comparison.verdict.outcome === 'both_succeeded' ? '[=]' :
+                 comparison.verdict.outcome === 'verify_regression' ? '[!]' :
+                 comparison.verdict.outcome === 'both_failed' ? '[x]' : '[-]';
+    log(`  Result: ${icon} ${comparison.verdict.outcome}`);
+  }
+
+  const summary = computeSummary(comparisons);
+  const apps = [...new Set(config.tasks.map(t => {
+    const parts = t.appDir.split('/');
+    return parts[parts.length - 1];
+  }))];
+
+  const run: BenchmarkRun = {
+    runId,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    llmProvider: config.llmProvider,
+    model: config.model,
+    apps,
+    comparisons,
+    summary,
+  };
+
+  // Print report
+  printReport(run);
+
+  // Save to disk
+  const reportPath = join(config.stateDir, `benchmark-${runId}.json`);
+  mkdirSync(config.stateDir, { recursive: true });
+  writeFileSync(reportPath, JSON.stringify(run, null, 2));
+  log(`Full results saved to: ${reportPath}`);
+
+  return run;
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function log(msg: string): void { console.log(msg); }
+function pad(n: number): string { return String(n).padStart(3); }
+function pct(n: number): string { return `${(n * 100).toFixed(1)}%`.padStart(6); }
+function ms(n: number): string { return `${(n / 1000).toFixed(1)}s`.padStart(6); }
+
+function emptyGroundTruth(): import('./types.js').GroundTruthResult {
+  return {
+    filesApplied: false,
+    fileErrors: ['No edits to apply'],
+    testsPass: null,
+    testOutput: '',
+    appStarts: true,
+    startupError: '',
+    contentPredicatesPass: false,
+    predicateResults: [],
+    goalAchieved: false,
+  };
+}

--- a/scripts/benchmark/types.ts
+++ b/scripts/benchmark/types.ts
@@ -1,0 +1,236 @@
+/**
+ * Benchmark Types — Head-to-Head: Agent With Verify vs. Without
+ * ==============================================================
+ *
+ * The one question: does verify actually make agents produce better code?
+ * Not internally. Not synthetic. Real tasks, real agents, real outcomes.
+ */
+
+import type { Edit, Predicate, VerifyResult, GroundingContext } from '../../src/types.js';
+import type { GovernResult, StopReason } from '../../src/govern.js';
+
+// =============================================================================
+// TASK DEFINITION
+// =============================================================================
+
+/** A single benchmark task — a real coding goal to attempt */
+export interface BenchmarkTask {
+  /** Unique task ID */
+  id: string;
+  /** Human-readable goal */
+  goal: string;
+  /** App directory to modify */
+  appDir: string;
+  /** Predicates the goal claims should be true after */
+  predicates: Predicate[];
+  /** Category for grouping results */
+  category: string;
+  /** Difficulty rating */
+  difficulty: 'trivial' | 'moderate' | 'hard' | 'adversarial';
+}
+
+// =============================================================================
+// INDEPENDENT VALIDATION (not verify — that's the whole point)
+// =============================================================================
+
+/**
+ * Ground-truth check — did the edit actually work?
+ * These checks are independent of verify's gate logic.
+ */
+export interface GroundTruthResult {
+  /** Did the file changes actually apply? (file exists, content changed) */
+  filesApplied: boolean;
+  /** Details of file check failures */
+  fileErrors: string[];
+
+  /** Did the app's own tests pass? (npm test, pytest, etc.) */
+  testsPass: boolean | null;
+  /** Test output (truncated) */
+  testOutput: string;
+
+  /** Does the app start without crashing? */
+  appStarts: boolean | null;
+  /** Startup error if any */
+  startupError: string;
+
+  /** Do content predicates hold? (checked independently, not by verify) */
+  contentPredicatesPass: boolean;
+  /** Per-predicate results */
+  predicateResults: Array<{
+    predicate: Predicate;
+    passed: boolean;
+    reason: string;
+  }>;
+
+  /** Overall: is the goal actually achieved? */
+  goalAchieved: boolean;
+}
+
+// =============================================================================
+// PER-TASK RESULTS
+// =============================================================================
+
+/** Result of running one task WITHOUT verify (raw agent output) */
+export interface RawRunResult {
+  /** The edits the agent produced */
+  edits: Edit[];
+  /** Predicates the agent claimed */
+  predicates: Predicate[];
+  /** Did the agent produce any edits at all? */
+  agentProducedEdits: boolean;
+  /** Agent error if it crashed */
+  agentError: string | null;
+  /** Independent ground-truth check of the raw output */
+  groundTruth: GroundTruthResult;
+  /** Time taken (ms) */
+  durationMs: number;
+  /** LLM tokens used */
+  tokens: { input: number; output: number };
+}
+
+/** Result of running one task WITH verify (govern loop) */
+export interface GovernedRunResult {
+  /** Final edits after convergence (or last attempt) */
+  edits: Edit[];
+  /** Final predicates */
+  predicates: Predicate[];
+  /** How many attempts govern used */
+  attempts: number;
+  /** Why govern stopped */
+  stopReason: StopReason;
+  /** Did govern converge (verify said pass)? */
+  verifyPassed: boolean;
+  /** Agent error if it crashed */
+  agentError: string | null;
+  /** Independent ground-truth check of the governed output */
+  groundTruth: GroundTruthResult;
+  /** Time taken (ms) */
+  durationMs: number;
+  /** Total LLM tokens across all attempts */
+  tokens: { input: number; output: number };
+}
+
+// =============================================================================
+// COMPARISON
+// =============================================================================
+
+/** Head-to-head result for one task */
+export interface TaskComparison {
+  task: BenchmarkTask;
+  raw: RawRunResult;
+  governed: GovernedRunResult;
+
+  /** The verdict: who actually achieved the goal? */
+  verdict: {
+    /** Raw agent achieved the goal (ground truth) */
+    rawAchieved: boolean;
+    /** Governed agent achieved the goal (ground truth) */
+    governedAchieved: boolean;
+    /** Classification */
+    outcome:
+      | 'verify_saved'        // raw failed, governed succeeded — verify made the difference
+      | 'both_succeeded'      // both achieved the goal — verify didn't hurt
+      | 'both_failed'         // neither achieved — verify didn't help here
+      | 'verify_overhead'     // raw succeeded, governed also succeeded but used more resources
+      | 'verify_regression'   // raw succeeded, governed failed — verify made it worse (should be rare)
+      | 'raw_no_edits'        // raw agent didn't produce edits
+      | 'governed_no_edits'   // governed agent didn't produce edits
+      | 'both_no_edits';      // neither produced edits
+  };
+}
+
+// =============================================================================
+// AGGREGATE RESULTS
+// =============================================================================
+
+/** Full benchmark run results */
+export interface BenchmarkRun {
+  /** Run identifier */
+  runId: string;
+  /** When it started */
+  startedAt: string;
+  /** When it completed */
+  completedAt: string;
+
+  /** LLM provider used */
+  llmProvider: string;
+  /** Model name */
+  model: string;
+  /** App(s) tested */
+  apps: string[];
+
+  /** Per-task comparisons */
+  comparisons: TaskComparison[];
+
+  /** Aggregate stats */
+  summary: BenchmarkSummary;
+}
+
+/** The numbers that matter */
+export interface BenchmarkSummary {
+  totalTasks: number;
+
+  // Raw agent (no verify)
+  raw: {
+    goalsAchieved: number;
+    goalsFailed: number;
+    noEdits: number;
+    successRate: number;  // goalsAchieved / totalTasks
+    avgDurationMs: number;
+    totalTokens: { input: number; output: number };
+  };
+
+  // Governed agent (with verify)
+  governed: {
+    goalsAchieved: number;
+    goalsFailed: number;
+    noEdits: number;
+    successRate: number;
+    avgAttempts: number;
+    avgDurationMs: number;
+    totalTokens: { input: number; output: number };
+  };
+
+  // Head-to-head
+  headToHead: {
+    verifySaved: number;        // verify made the difference
+    bothSucceeded: number;      // both fine
+    bothFailed: number;         // neither worked
+    verifyOverhead: number;     // both worked but verify used more resources
+    verifyRegression: number;   // verify made it worse
+  };
+
+  // The headline number
+  /** (governed.successRate - raw.successRate) / raw.successRate */
+  improvementPercent: number;
+  /** Net tasks saved by verify (verifySaved - verifyRegression) */
+  netTasksSaved: number;
+}
+
+// =============================================================================
+// CONFIG
+// =============================================================================
+
+export interface BenchmarkConfig {
+  /** Tasks to run */
+  tasks: BenchmarkTask[];
+  /** LLM call function */
+  llm: LLMCallFn;
+  /** Provider name for reporting */
+  llmProvider: string;
+  /** Model name for reporting */
+  model: string;
+  /** Max attempts for govern() (default: 3) */
+  maxGovAttempts: number;
+  /** State directory */
+  stateDir: string;
+  /** Show verbose output */
+  verbose: boolean;
+  /** Skip ground-truth checks that require Docker */
+  skipDocker: boolean;
+}
+
+export type LLMCallFn = (
+  systemPrompt: string,
+  userPrompt: string,
+) => Promise<{ text: string; inputTokens: number; outputTokens: number }>;


### PR DESCRIPTION
## Summary

- **Benchmark harness** (`scripts/benchmark/`): Head-to-head A/B test — same LLM, same tasks, two paths (raw agent vs. govern loop). Ground truth validator is independent of verify to prevent circular reasoning. Supports Gemini, Claude, Anthropic, Ollama.
- **Marketing strategy** (`MARKETING-STRATEGY.md`): Reframed around proof-first approach. The benchmark is Step 0 — run it before any content, demos, or social posts. The numbers become the marketing.

## What the benchmark measures

```
                          Raw Agent    With Verify
Goals achieved:             ??            ??
Success rate:             ??.?%         ??.?%
```

Plus head-to-head breakdown: verify_saved, both_succeeded, both_failed, verify_regression.

## How to run

```bash
GEMINI_API_KEY=... npx tsx scripts/benchmark/benchmark.ts \
  --app=fixtures/demo-app --tasks=20 --llm=gemini --verbose
```

## Test plan

- [ ] Run benchmark against demo-app with Gemini Flash (~20 tasks)
- [ ] Run benchmark against demo-app with Claude (~20 tasks)
- [ ] Verify ground-truth validator catches real file-level failures
- [ ] Confirm govern() path retries and converges on failing tasks
- [ ] Review marketing strategy doc for accuracy

https://claude.ai/code/session_01LYuCQcg6MC2hbZ3CorzCcZ